### PR TITLE
Auto attach to Path Of Exile (64 bit) process when the table launches

### DIFF
--- a/src/maper_CE_3.12.4.ct
+++ b/src/maper_CE_3.12.4.ct
@@ -765,4 +765,15 @@ unregistersymbol(PathOfExile_x64.exe)
   <UserdefinedSymbols/>
   <Comments>Info about this table:
 </Comments>
+  <LuaScript>function poeattach(timer)
+  if getProcessIDFromProcessName("PathOfExile_x64.exe") ~= nil then
+    object_destroy(timer)
+    openProcess("PathOfExile_x64.exe")
+  end
+end
+
+t=createTimer(nil);
+timer_setInterval(t,10)
+timer_onTimer(t,poeattach)
+</LuaScript>
 </CheatTable>


### PR DESCRIPTION
I have only tried this on POE 64 bit desktop client. It should work on other clients too but it isn't tested